### PR TITLE
#18; Installs report parser.

### DIFF
--- a/initScripts/aarch64/Ubuntu_16.04/Docker_17.06.sh
+++ b/initScripts/aarch64/Ubuntu_16.04/Docker_17.06.sh
@@ -28,6 +28,7 @@ export REQPROC_CONTAINER_NAME_PATTERN="reqProc"
 export EXEC_CONTAINER_NAME_PATTERN="shippable-exec"
 export REQPROC_CONTAINER_NAME="$REQPROC_CONTAINER_NAME_PATTERN-$BASE_UUID"
 export REQKICK_SERVICE_NAME_PATTERN="shippable-reqKick@"
+export REPORTS_BINARY_LOCATION_ON_HOST="/pipelines/reports"
 export DEFAULT_TASK_CONTAINER_MOUNTS="-v $BUILD_DIR:$BUILD_DIR \
   -v $REQEXEC_DIR:/reqExec"
 export TASK_CONTAINER_COMMAND="/reqExec/$NODE_ARCHITECTURE/$NODE_OPERATING_SYSTEM/dist/main/main"
@@ -451,6 +452,20 @@ remove_reqKick() {
   systemctl daemon-reload
 }
 
+fetch_reports_binary() {
+  __process_marker "Installing report parser..."
+
+  local reports_dir="$REPORTS_BINARY_LOCATION_ON_HOST"
+  local reports_tar_file="reports.tar.gz"
+  rm -rf $reports_dir
+  mkdir -p $reports_dir
+  pushd $reports_dir
+    wget $REPORTS_DOWNLOAD_URL -O $reports_tar_file
+    tar -xf $reports_tar_file
+    rm -rf $reports_tar_file
+  popd
+}
+
 boot_reqProc() {
   __process_marker "Booting up reqProc..."
   docker pull $EXEC_IMAGE
@@ -558,6 +573,9 @@ main() {
 
   trap before_exit EXIT
   exec_grp "remove_reqKick"
+
+  trap before_exit EXIT
+  exec_grp "fetch_reports_binary"
 
   trap before_exit EXIT
   exec_grp "boot_reqProc"

--- a/initScripts/x86_64/CentOS_7/Docker_17.06.sh
+++ b/initScripts/x86_64/CentOS_7/Docker_17.06.sh
@@ -239,6 +239,20 @@ install_ntp() {
   fi
 }
 
+fetch_reports_binary() {
+  __process_marker "Installing report parser..."
+
+  local reports_dir="/pipelines/reports"
+  local reports_tar_file="reports.tar.gz"
+  rm -rf $reports_dir
+  mkdir -p $reports_dir
+  pushd $reports_dir
+    wget $REPORTS_DOWNLOAD_URL -O $reports_tar_file
+    tar -xf $reports_tar_file
+    rm -rf $reports_tar_file
+  popd
+}
+
 pull_reqProc() {
   __process_marker "Pulling reqProc..."
   docker pull $EXEC_IMAGE
@@ -319,6 +333,9 @@ main() {
 
     trap before_exit EXIT
     exec_grp "install_ntp"
+
+    trap before_exit EXIT
+    exec_grp "fetch_reports_binary"
 
     trap before_exit EXIT
     exec_grp "pull_reqProc"

--- a/initScripts/x86_64/CentOS_7/Docker_18.03.sh
+++ b/initScripts/x86_64/CentOS_7/Docker_18.03.sh
@@ -239,6 +239,20 @@ install_ntp() {
   fi
 }
 
+fetch_reports_binary() {
+  __process_marker "Installing report parser..."
+
+  local reports_dir="/pipelines/reports"
+  local reports_tar_file="reports.tar.gz"
+  rm -rf $reports_dir
+  mkdir -p $reports_dir
+  pushd $reports_dir
+    wget $REPORTS_DOWNLOAD_URL -O $reports_tar_file
+    tar -xf $reports_tar_file
+    rm -rf $reports_tar_file
+  popd
+}
+
 pull_reqProc() {
   __process_marker "Pulling reqProc..."
   docker pull $EXEC_IMAGE
@@ -319,6 +333,9 @@ main() {
 
     trap before_exit EXIT
     exec_grp "install_ntp"
+
+    trap before_exit EXIT
+    exec_grp "fetch_reports_binary"
 
     trap before_exit EXIT
     exec_grp "pull_reqProc"

--- a/initScripts/x86_64/RHEL_7/Docker_17.06.sh
+++ b/initScripts/x86_64/RHEL_7/Docker_17.06.sh
@@ -32,6 +32,7 @@ export REQPROC_OPTS=""
 export REQPROC_CONTAINER_NAME_PATTERN="reqProc"
 export REQPROC_CONTAINER_NAME="$REQPROC_CONTAINER_NAME_PATTERN-$BASE_UUID"
 export REQKICK_SERVICE_NAME_PATTERN="shippable-reqKick@"
+export REPORTS_BINARY_LOCATION_ON_HOST="/pipelines/reports"
 export DEFAULT_TASK_CONTAINER_MOUNTS="-v $BUILD_DIR:$BUILD_DIR \
   -v $REQEXEC_DIR:/reqExec"
 export TASK_CONTAINER_COMMAND="/reqExec/$NODE_ARCHITECTURE/$NODE_OPERATING_SYSTEM/dist/main/main"
@@ -371,6 +372,20 @@ remove_reqKick() {
   systemctl daemon-reload
 }
 
+fetch_reports_binary() {
+  __process_marker "Installing report parser..."
+
+  local reports_dir="$REPORTS_BINARY_LOCATION_ON_HOST"
+  local reports_tar_file="reports.tar.gz"
+  rm -rf $reports_dir
+  mkdir -p $reports_dir
+  pushd $reports_dir
+    wget $REPORTS_DOWNLOAD_URL -O $reports_tar_file
+    tar -xf $reports_tar_file
+    rm -rf $reports_tar_file
+  popd
+}
+
 boot_reqProc() {
   __process_marker "Booting up reqProc..."
   docker pull $EXEC_IMAGE
@@ -501,6 +516,9 @@ main() {
 
     trap before_exit EXIT
     exec_grp "remove_reqKick"
+
+    trap before_exit EXIT
+    exec_grp "fetch_reports_binary"
 
     trap before_exit EXIT
     exec_grp "boot_reqProc"

--- a/initScripts/x86_64/RHEL_7/Docker_18.03.sh
+++ b/initScripts/x86_64/RHEL_7/Docker_18.03.sh
@@ -32,6 +32,7 @@ export REQPROC_OPTS=""
 export REQPROC_CONTAINER_NAME_PATTERN="reqProc"
 export REQPROC_CONTAINER_NAME="$REQPROC_CONTAINER_NAME_PATTERN-$BASE_UUID"
 export REQKICK_SERVICE_NAME_PATTERN="shippable-reqKick@"
+export REPORTS_BINARY_LOCATION_ON_HOST="/pipelines/reports"
 export DEFAULT_TASK_CONTAINER_MOUNTS="-v $BUILD_DIR:$BUILD_DIR \
   -v $REQEXEC_DIR:/reqExec"
 export TASK_CONTAINER_COMMAND="/reqExec/$NODE_ARCHITECTURE/$NODE_OPERATING_SYSTEM/dist/main/main"
@@ -370,6 +371,20 @@ remove_reqKick() {
   systemctl daemon-reload
 }
 
+fetch_reports_binary() {
+  __process_marker "Installing report parser..."
+
+  local reports_dir="$REPORTS_BINARY_LOCATION_ON_HOST"
+  local reports_tar_file="reports.tar.gz"
+  rm -rf $reports_dir
+  mkdir -p $reports_dir
+  pushd $reports_dir
+    wget $REPORTS_DOWNLOAD_URL -O $reports_tar_file
+    tar -xf $reports_tar_file
+    rm -rf $reports_tar_file
+  popd
+}
+
 boot_reqProc() {
   __process_marker "Booting up reqProc..."
   docker pull $EXEC_IMAGE
@@ -500,6 +515,9 @@ main() {
 
     trap before_exit EXIT
     exec_grp "remove_reqKick"
+
+    trap before_exit EXIT
+    exec_grp "fetch_reports_binary"
 
     trap before_exit EXIT
     exec_grp "boot_reqProc"

--- a/initScripts/x86_64/Ubuntu_16.04/Docker_18.03.sh
+++ b/initScripts/x86_64/Ubuntu_16.04/Docker_18.03.sh
@@ -235,6 +235,20 @@ install_ntp() {
   fi
 }
 
+fetch_reports_binary() {
+  __process_marker "Installing report parser..."
+
+  local reports_dir="/pipelines/reports"
+  local reports_tar_file="reports.tar.gz"
+  rm -rf $reports_dir
+  mkdir -p $reports_dir
+  pushd $reports_dir
+    wget $REPORTS_DOWNLOAD_URL -O $reports_tar_file
+    tar -xf $reports_tar_file
+    rm -rf $reports_tar_file
+  popd
+}
+
 pull_reqProc() {
   __process_marker "Pulling reqProc..."
 
@@ -313,6 +327,9 @@ main() {
 
     trap before_exit EXIT
     exec_grp "install_ntp"
+
+    trap before_exit EXIT
+    exec_grp "fetch_reports_binary"
 
     trap before_exit EXIT
     exec_grp "pull_reqProc"


### PR DESCRIPTION
#18 

Installs the `reports` binary in the same way as Shippable/node.  Only the x86_64 Ubuntu 16.04 script has been tested.