### PR TITLE
Moves reqKick to correct location

### DIFF
--- a/initScripts/x86_64/WindowsServer_2019/Docker_18.09.ps1
+++ b/initScripts/x86_64/WindowsServer_2019/Docker_18.09.ps1
@@ -123,6 +123,7 @@ Function fetch_reqKick() {
   }
   mkdir -p $REQKICK_DIR
   Expand-Archive -LiteralPath $reqKick_zip_download_location -DestinationPath $REQKICK_DIR
+  Move-Item -Force $REQKICK_DIR\kermit-reqKick-master\* -Destination $REQKICK_DIR
 
   pushd $REQKICK_DIR
   npm install


### PR DESCRIPTION
https://github.com/Shippable/kermit-nodeInit/issues/31

Since we are using reqKick generated from github produced zip file instead of the one packged from our S3, the path of the files changed. Hence moving the files to a correct place.

```
Error: Cannot find module 'C:\Users\Administrator\Shippable\reqKick\reqKick.app.js'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:191:16)
    at bootstrap_node.js:612:3
module.js:549
    throw err;
    ^
```