### PR TITLE
Set docker IP for Windows Server 2019 using docker command

### DIFF
--- a/initScripts/x86_64/WindowsServer_2019/boot.ps1
+++ b/initScripts/x86_64/WindowsServer_2019/boot.ps1
@@ -48,7 +48,7 @@ $REQKICK_SERVICE_NAME = "shippable-reqkick-$BASE_UUID"
 
 $BUILD_DIR = "$BASE_DIR\build"
 $CONTAINER_BUILD_DIR = "$CONTAINER_BASE_DIR\build"
-$STATUS_DIR = "$BUILD_DIR\status"
+$STATUS_DIR = "$BASE_DIR\status"
 $SCRIPTS_DIR = "$BUILD_DIR\scripts"
 
 $REQPROC_MOUNTS = ""

--- a/initScripts/x86_64/WindowsServer_2019/boot.ps1
+++ b/initScripts/x86_64/WindowsServer_2019/boot.ps1
@@ -149,7 +149,7 @@ Function setup_mounts() {
 
 Function setup_envs() {
   # Get docker NAT gateway ip address
-  $DOCKER_NAT_IP=(Get-NetIPConfiguration | Where-Object InterfaceAlias -eq "vEthernet (HNS Internal NIC)").IPv4Address.IPAddress
+  $DOCKER_NAT_IP=(docker network inspect nat --format="{{(index (index .).IPAM.Config 0).Gateway}}")
 
   $global:REQPROC_ENVS = " -e SHIPPABLE_AMQP_URL=$SHIPPABLE_AMQP_URL " + `
     "-e SHIPPABLE_AMQP_DEFAULT_EXCHANGE=$SHIPPABLE_AMQP_DEFAULT_EXCHANGE " + `


### PR DESCRIPTION
https://github.com/Shippable/reqProc/issues/494

Older docker versions created `vEthernet (HNS Internal NIC)` which gave the value of `DOCKER_HOST`.

The latest docker version 18.09 does not contain `vEthernet (HNS Internal NIC)` instead has `vEthernet (nat)`. So changing the code to get the DOCKER_HOST IP using the docker network command. ([Reference](https://docs.microsoft.com/en-us/virtualization/windowscontainers/container-networking/architecture))

Also, fixed the directory path of `STATUS_DIR` for proper functioning of reqKick.